### PR TITLE
Add CLI option to set pylint location

### DIFF
--- a/pylint_to_ruff/cli.py
+++ b/pylint_to_ruff/cli.py
@@ -26,9 +26,16 @@ def cli():
         default=False,
         help="Don't print commented-out unsupported rules",
     )
+    ap.add_argument(
+        "--pylint-bin",
+        type=str,
+        default="pylint",
+        help="Full path to pylint if not on path",
+    )
+
     args = ap.parse_args()
     wd = args.wd
-    pmc = get_pylint_message_control_output(wd)
+    pmc = get_pylint_message_control_output(wd, args.pylint_bin)
     ruffverse = get_ruffverse()
     config = get_ruff_config_segment(
         pmc,

--- a/pylint_to_ruff/pylint.py
+++ b/pylint_to_ruff/pylint.py
@@ -21,10 +21,10 @@ def parse_pylint_msg_spec(spec: str) -> PylintMessage:
     return PylintMessage(name, code)
 
 
-def get_pylint_message_control_output(working_directory: str) -> PylintMessageConfig:
+def get_pylint_message_control_output(working_directory: str, pylint_bin: str) -> PylintMessageConfig:
     pmc = PylintMessageConfig()
     current = None
-    command = ["pylint", "--list-msgs-enabled"]
+    command = [pylint_bin, "--list-msgs-enabled"]
     pylintrc_file = os.path.join(working_directory, ".pylintrc")
     if os.path.isfile(pylintrc_file):
         command += ["--rcfile", pylintrc_file]


### PR DESCRIPTION
Allows the user to override the full path to pylint used to generate the config.

Useful if the pylint command is not in a standard location, or you wish to specify one installed elsewhere.